### PR TITLE
Arreglo de CI

### DIFF
--- a/src/tests/App.test.js
+++ b/src/tests/App.test.js
@@ -27,7 +27,15 @@ describe('<App/> renderizando <LogIn/>', () => {
 
 test('Se puede enviar el formulario llenando los campos', () => {
   const loginCall = jest.spyOn(authService, 'login');
-  loginCall.mockImplementation(() => Promise.resolve({}));
+  const error = {
+          response: {
+            status: 400,
+            data: {
+                message: 'ocurrio algo malo',
+            }
+          }
+  };
+  loginCall.mockImplementation(() => Promise.reject(error));
   const { getByTestId } = render(<App/>);
   const usernameInput = getByTestId('username');
   const passwordInput = getByTestId('password');


### PR DESCRIPTION
Lo que pasó fue que habia respuestas mockeadas que retornaban objetos vacios y los componentes intentaban acceder a informacion de ese objeto vacío, si bien no se van a usar esos objetos en el test, son necesarios para que terminen de renderizarse bien los componentes